### PR TITLE
doc(README): correct copy+pasta in active team members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Pull Requests: propose & plan features, add minuting minutes
 
 * Aviv Keller [@avivkeller](https://github.com/avivkeller)
 * Colin Ihrig [@cjihrig](https://github.com/cjihrig)
-* Jacob Smith [@JakobJingleheimer](https://github.com/JakobJingleheimer) (chair)
+* Jacob Smith [@JakobJingleheimer](https://github.com/JakobJingleheimer)
 * Moshe Atlow [@MoLow](https://github.com/MoLow)
 * Pietro Marchini [@pmarchini](https://github.com/pmarchini)


### PR DESCRIPTION
I had copied the list from the first meeting minutes (that I chaired). I didn't intend to appoint myself chair for life 😆