### PR TITLE
Proposal: Multiple Snapshot Formats

### DIFF
--- a/proposals/multiple-snapshot-formats.md
+++ b/proposals/multiple-snapshot-formats.md
@@ -1,0 +1,33 @@
+# Support Multiple Snapshot Formats in the Node.js Test Runner
+
+The current snapshot implementation in the Node.js Test Runner assumes a single snapshot file format (`.snapshot`).
+
+However, Node.js itself natively supports multiple module and data formats:
+
+* `.cjs` (CommonJS)
+* `.mjs` (ESM)
+* `.js` (Both)
+* `.json`
+
+The test runner already embraces this flexibility for **test files themselves** (it automatically discovers `.js`, `.cjs`, and `.mjs` test files), so one would expect snapshots to be loadable the same way.
+
+## Goal
+
+When resolving a snapshot file, the test runner should support multiple extensions.
+
+Example resolution order:
+
+```text
+<test>.snapshot.mjs
+<test>.snapshot.cjs
+<test>.snapshot.js
+<test>.snapshot.json
+```
+
+Example error:
+
+```
+Multiple snapshot files found for test "foo.test.js":
+- foo.test.snapshot.mjs
+- foo.test.snapshot.json
+```


### PR DESCRIPTION
As discussed in today's meeting, I feel that we should apply the same logic that we do to finding tests that we do to finding snapshots.

As for generating them, I think we should generate the snapshot either:
- Always CJS (Status Quo)
- Always ESM
- Use `module` from `package.json`
- Use `--experimental-snapshot-format=[cjs|mjs|json]`
- Use type of test (e.g. `.test.cjs` -> `.snapshot.cjs`)

There are plenty of times where it would be beneficial to support JSON snapshots (and ESM). For instance, if a non-JS runtime needs to access these files, they may not have the parsing capability to deconstruct a CJS file, but they will have the ability to read a JSON fiel.